### PR TITLE
Added auto permission prompt flag for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ AppRegistry.registerComponent('example', () => example);
 | localSourceImage | `object` | Require an object (see [below](#objects)) which consists of `filename`, `directory`(optional) and `mode`(optional). If set, the image will be loaded and display as a background in canvas. (Thanks to diego-caceres-galvan))([Here](#background-image) for details) |
 | permissionDialogTitle | `string` | Android Only: Provide a Dialog Title for the Image Saving PermissionDialog. Defaults to empty string if not set |
 | permissionDialogMessage | `string` | Android Only: Provide a Dialog Message for the Image Saving PermissionDialog. Defaults to empty string if not set |
+| autoAskPermission | `boolean` | Android Only: Flag for above "permissions" props to trigger |
 
 #### Methods
 -------------

--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ export default class RNSketchCanvas extends React.Component {
 
     permissionDialogTitle: PropTypes.string,
     permissionDialogMessage: PropTypes.string,
+    autoAskPermission: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -117,6 +118,7 @@ export default class RNSketchCanvas extends React.Component {
 
     permissionDialogTitle: '',
     permissionDialogMessage: '',
+    autoAskPermission: false
   };
 
 
@@ -195,6 +197,7 @@ export default class RNSketchCanvas extends React.Component {
   }
 
   async componentDidMount() {
+    if (!this.props.autoAskPermission) return;
     const isStoragePermissionAuthorized = await requestPermissions(
       this.props.permissionDialogTitle,
       this.props.permissionDialogMessage,


### PR DESCRIPTION
This PR added one extra flag for permission handling. Some people may not want to have the canvas component to ask for permission automatically like it is currently doing.
